### PR TITLE
Add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 # draughtsman-operator
 The draughtsman-operator is an in-cluster agent that handles Helm based
 deployments on behalf of the draughtsmantpr.
+
+**DEPRECATED** `draughtsman-operator` is deprecated and [draughtsman](https://github.com/giantswarm/draughtsman)
+is still used in production. It will be replaced by [chart-operator](https://github.com/giantswarm/chart-operator).
+
+TODO: Delete repo once `chart-operator` is in production.

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ deployments on behalf of the draughtsmantpr.
 **DEPRECATED** `draughtsman-operator` is deprecated and [draughtsman](https://github.com/giantswarm/draughtsman)
 is still used in production. It will be replaced by [chart-operator](https://github.com/giantswarm/chart-operator).
 
-TODO: Delete repo once `chart-operator` is in production.
+**TODO:** Delete repo once `chart-operator` is in production.


### PR DESCRIPTION
Updates the readme now that we're going with `chart-operator`.

I don't want to delete the repo just yet. As it might be useful for reference while we build the new operator.